### PR TITLE
fixing version number bug

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -59,7 +59,7 @@ jobs:
           echo "tag_full=${TAG}" >> $GITHUB_OUTPUT
           echo "tag_version=${BASE}" >> $GITHUB_OUTPUT
           echo "tag_patch=${PATCH}" >> $GITHUB_OUTPUT
-          echo "tag_feature=v{MAJOR}.${MINOR}.0" >> $GITHUB_OUTPUT
+          echo "tag_feature=v${MAJOR}.${MINOR}.0" >> $GITHUB_OUTPUT
           
           if [ "$PATCH" -eq 0 ]; then
             echo "announce_release=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
deploy action was not announcing version due to a missed string variable parse