### PR TITLE
installing jq on deployment machine

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Compute Sunder version from tags
         id: version
         run: |


### PR DESCRIPTION
deployment action returned an error, apparently ubuntu-latest doesnt come with jq preinstalled